### PR TITLE
Fix dark theme display and group saving

### DIFF
--- a/src/components/GoSplit/AddExpenseModal.jsx
+++ b/src/components/GoSplit/AddExpenseModal.jsx
@@ -210,11 +210,11 @@ export default function AddExpenseModal({ isOpen, onClose, groupId, members }) {
         <div className="p-6">
           {/* Header */}
           <div className="flex justify-between items-center mb-6">
-            <h2 className="text-2xl font-bold" style={{color: 'black'}}>Add New Expense</h2>
+            <h2 className="text-2xl font-bold" style={{color: 'var(--text)'}}>Add New Expense</h2>
             <button
               onClick={onClose}
               className="hover:opacity-70 text-2xl"
-              style={{color: 'black'}}
+              style={{color: 'var(--text)'}}
             >
               ×
             </button>
@@ -223,7 +223,7 @@ export default function AddExpenseModal({ isOpen, onClose, groupId, members }) {
           {/* Basic Details */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
             <div className="md:col-span-2">
-              <label className="block text-sm font-medium mb-2" style={{color: 'black'}}>
+              <label className="block text-sm font-medium mb-2" style={{color: 'var(--text)'}}>
                 Description *
               </label>
               <input
@@ -237,7 +237,7 @@ export default function AddExpenseModal({ isOpen, onClose, groupId, members }) {
             </div>
 
             <div>
-              <label className="block text-sm font-medium mb-2" style={{color: 'black'}}>
+              <label className="block text-sm font-medium mb-2" style={{color: 'var(--text)'}}>
                 Amount (₹) *
               </label>
               <input
@@ -252,7 +252,7 @@ export default function AddExpenseModal({ isOpen, onClose, groupId, members }) {
             </div>
 
             <div>
-              <label className="block text-sm font-medium mb-2" style={{color: 'black'}}>
+              <label className="block text-sm font-medium mb-2" style={{color: 'var(--text)'}}>
                 Paid by *
               </label>
               <select
@@ -269,7 +269,7 @@ export default function AddExpenseModal({ isOpen, onClose, groupId, members }) {
             </div>
 
             <div>
-              <label className="block text-sm font-medium mb-2" style={{color: 'black'}}>
+              <label className="block text-sm font-medium mb-2" style={{color: 'var(--text)'}}>
                 Category
               </label>
               <div className="grid grid-cols-4 gap-2">
@@ -292,7 +292,7 @@ export default function AddExpenseModal({ isOpen, onClose, groupId, members }) {
             </div>
 
             <div>
-              <label className="block text-sm font-medium mb-2" style={{color: 'black'}}>
+              <label className="block text-sm font-medium mb-2" style={{color: 'var(--text)'}}>
                 Date
               </label>
               <input
@@ -307,7 +307,7 @@ export default function AddExpenseModal({ isOpen, onClose, groupId, members }) {
 
           {/* Split Options */}
           <div className="mb-6">
-            <label className="block text-sm font-medium mb-3" style={{color: 'black'}}>
+            <label className="block text-sm font-medium mb-3" style={{color: 'var(--text)'}}>
               How to split?
             </label>
             
@@ -336,14 +336,14 @@ export default function AddExpenseModal({ isOpen, onClose, groupId, members }) {
             {/* Split Details */}
             {formData.amount && parseFloat(formData.amount) > 0 && (
               <div className="bg-gray-50 rounded-lg p-4" style={{backgroundColor: '#f9fafb'}}>
-                <h4 className="font-medium mb-3" style={{color: 'black'}}>Split breakdown:</h4>
+                <h4 className="font-medium mb-3" style={{color: 'var(--text)'}}>Split breakdown:</h4>
                 
                 {splitType === 'equal' && (
                   <div className="space-y-2">
                     {members.map((member) => (
                       <div key={member} className="flex justify-between items-center">
-                        <span style={{color: 'black'}}>{member}</span>
-                        <span className="font-medium" style={{color: 'black'}}>₹{(parseFloat(formData.amount) / members.length).toFixed(2)}</span>
+                                            <span style={{color: 'var(--text)'}}>{member}</span>
+                    <span className="font-medium" style={{color: 'var(--text)'}}>₹{(parseFloat(formData.amount) / members.length).toFixed(2)}</span>
                       </div>
                     ))}
                   </div>

--- a/src/components/GoSplit/CreateGroupModal.jsx
+++ b/src/components/GoSplit/CreateGroupModal.jsx
@@ -105,11 +105,11 @@ export default function CreateGroupModal({ isOpen, onClose }) {
         <div className="p-6">
           {/* Header */}
           <div className="flex justify-between items-center mb-6">
-            <h2 className="text-2xl font-bold" style={{color: 'black'}}>Create New Group</h2>
+            <h2 className="text-2xl font-bold" style={{color: 'var(--text)'}}>Create New Group</h2>
             <button
               onClick={onClose}
               className="hover:opacity-70 text-2xl"
-              style={{color: 'black'}}
+              style={{color: 'var(--text)'}}
             >
               ×
             </button>
@@ -117,7 +117,7 @@ export default function CreateGroupModal({ isOpen, onClose }) {
 
           {/* Group Name */}
           <div className="mb-4">
-            <label className="block text-sm font-medium mb-2" style={{color: 'black'}}>
+            <label className="block text-sm font-medium mb-2" style={{color: 'var(--text)'}}>
               Group Name *
             </label>
             <input
@@ -133,7 +133,7 @@ export default function CreateGroupModal({ isOpen, onClose }) {
 
           {/* Emoji Selection */}
           <div className="mb-4">
-            <label className="block text-sm font-medium mb-2" style={{color: 'black'}}>
+            <label className="block text-sm font-medium mb-2" style={{color: 'var(--text)'}}>
               Group Icon
             </label>
             <div className="flex flex-wrap gap-2">
@@ -155,11 +155,11 @@ export default function CreateGroupModal({ isOpen, onClose }) {
 
           {/* Budget (Optional) */}
           <div className="mb-4">
-            <label className="block text-sm font-medium mb-2" style={{color: 'black'}}>
+            <label className="block text-sm font-medium mb-2" style={{color: 'var(--text)'}}>
               Budget (Optional)
             </label>
             <div className="relative">
-              <span className="absolute left-3 top-3" style={{color: 'black'}}>₹</span>
+              <span className="absolute left-3 top-3" style={{color: 'gray'}}>₹</span>
               <input
                 type="number"
                 value={budget}
@@ -169,15 +169,15 @@ export default function CreateGroupModal({ isOpen, onClose }) {
                 style={{color: 'black', backgroundColor: 'white'}}
               />
             </div>
-            <p className="text-xs mt-1" style={{color: 'black'}}>Set a budget cap to track spending</p>
+            <p className="text-xs mt-1" style={{color: 'var(--text)'}}>Set a budget cap to track spending</p>
           </div>
 
           {/* Members */}
           <div className="mb-6">
-            <label className="block text-sm font-medium mb-2" style={{color: 'black'}}>
+            <label className="block text-sm font-medium mb-2" style={{color: 'var(--text)'}}>
               Add Members (Optional)
             </label>
-            <p className="text-xs mb-3" style={{color: 'black'}}>
+            <p className="text-xs mb-3" style={{color: 'var(--text)'}}>
               Add member emails or names. You can also invite them later using the invite code.
             </p>
             
@@ -215,7 +215,7 @@ export default function CreateGroupModal({ isOpen, onClose }) {
             <button
               onClick={onClose}
               className="flex-1 py-3 px-4 border border-gray-300 rounded-lg hover:bg-gray-50 transition duration-200"
-              style={{color: 'black', backgroundColor: 'white'}}
+              style={{color: 'var(--text)', backgroundColor: 'var(--bg)'}}
             >
               Cancel
             </button>

--- a/src/components/GoSplit/GroupList.jsx
+++ b/src/components/GoSplit/GroupList.jsx
@@ -55,20 +55,20 @@ export default function GroupList() {
       <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center p-4">
         <div className="bg-white rounded-xl shadow-2xl p-8 w-full max-w-md text-center" style={{backgroundColor: 'var(--bg)', color: 'var(--text)'}}>
           <div className="text-6xl mb-6">🤝</div>
-          <h1 className="text-3xl font-bold mb-4" style={{color: 'black'}}>Welcome to GoSplit</h1>
-          <p className="mb-6" style={{color: 'black'}}>
-            Split travel expenses with your friends and family. Sign in to get started.
-          </p>
-          <div className="bg-blue-50 p-4 rounded-lg mb-6">
-            <p className="text-sm" style={{color: 'black'}}>
-              <strong>📱 Your Data is Safe:</strong><br/>
-              All your groups and expenses are stored securely in the cloud. 
-              When you sign in, you'll see all your data exactly as you left it.
+                      <h1 className="text-3xl font-bold mb-4" style={{color: 'var(--text)'}}>Welcome to GoSplit</h1>
+            <p className="mb-6" style={{color: 'var(--text)'}}>
+              Split travel expenses with your friends and family. Sign in to get started.
             </p>
-          </div>
-          <p className="text-sm" style={{color: 'black'}}>
-            Please sign in using the button in the top right corner of the page.
-          </p>
+            <div className="bg-blue-50 p-4 rounded-lg mb-6">
+              <p className="text-sm" style={{color: 'var(--text)'}}>
+                <strong>📱 Your Data is Safe:</strong><br/>
+                All your groups and expenses are stored securely in the cloud. 
+                When you sign in, you'll see all your data exactly as you left it.
+              </p>
+            </div>
+            <p className="text-sm" style={{color: 'var(--text)'}}>
+              Please sign in using the button in the top right corner of the page.
+            </p>
         </div>
       </div>
     );
@@ -89,8 +89,8 @@ export default function GroupList() {
         <div className="bg-white rounded-xl shadow-lg p-6 mb-6" style={{backgroundColor: 'var(--bg)', color: 'var(--text)'}}>
             <div className="flex justify-between items-center mb-4">
               <div>
-                <h1 className="text-3xl font-bold" style={{color: 'black'}}>GoSplit</h1>
-                <p style={{color: 'black'}}>Split expenses with your travel groups</p>
+                <h1 className="text-3xl font-bold" style={{color: 'var(--text)'}}>GoSplit</h1>
+                <p style={{color: 'var(--text)'}}>Split expenses with your travel groups</p>
               </div>
               <div className="flex space-x-3">
                 <button
@@ -115,8 +115,8 @@ export default function GroupList() {
         {groups.length === 0 ? (
           <div className="bg-white rounded-xl shadow-lg p-8 text-center" style={{backgroundColor: 'var(--bg)', color: 'var(--text)'}}>
             <div className="text-6xl mb-4">🏖️</div>
-            <h3 className="text-xl font-semibold mb-2" style={{color: 'black'}}>No Groups Yet</h3>
-            <p className="mb-6" style={{color: 'black'}}>Create your first travel group or join an existing one to start splitting expenses!</p>
+            <h3 className="text-xl font-semibold mb-2" style={{color: 'var(--text)'}}>No Groups Yet</h3>
+            <p className="mb-6" style={{color: 'var(--text)'}}>Create your first travel group or join an existing one to start splitting expenses!</p>
             <div className="flex justify-center space-x-4">
               <button
                 onClick={() => setShowCreateModal(true)}
@@ -142,21 +142,21 @@ export default function GroupList() {
                 style={{backgroundColor: 'var(--bg)', color: 'var(--text)'}}
               >
                 <div className="flex items-center justify-between mb-4">
-                  <h3 className="text-xl font-semibold truncate" style={{color: 'black'}}>{group.name}</h3>
+                  <h3 className="text-xl font-semibold truncate" style={{color: 'var(--text)'}}>{group.name}</h3>
                   <span className="text-2xl">{group.emoji || '🌟'}</span>
                 </div>
                 
                 <div className="space-y-2 mb-4">
-                  <div className="flex items-center text-sm" style={{color: 'black'}}>
+                  <div className="flex items-center text-sm" style={{color: 'var(--text)'}}>
                     <span className="mr-2">👥</span>
                     <span>{group.members?.length || 0} members</span>
                   </div>
-                  <div className="flex items-center text-sm" style={{color: 'black'}}>
+                  <div className="flex items-center text-sm" style={{color: 'var(--text)'}}>
                     <span className="mr-2">💰</span>
                     <span>{group.totalExpenses || 0} expenses</span>
                   </div>
                   {group.budget && (
-                    <div className="flex items-center text-sm" style={{color: 'black'}}>
+                    <div className="flex items-center text-sm" style={{color: 'var(--text)'}}>
                       <span className="mr-2">🎯</span>
                       <span>Budget: ₹{group.budget}</span>
                     </div>
@@ -164,7 +164,7 @@ export default function GroupList() {
                 </div>
 
                 <div className="flex items-center justify-between">
-                  <div className="text-xs" style={{color: 'black'}}>
+                  <div className="text-xs" style={{color: 'var(--text)'}}>
                     Created {group.createdAt?.toDate?.()?.toLocaleDateString() || 'Recently'}
                   </div>
                   <div className="text-indigo-500 font-medium">View Details →</div>

--- a/src/components/GoSplit/JoinGroupModal.jsx
+++ b/src/components/GoSplit/JoinGroupModal.jsx
@@ -73,11 +73,11 @@ export default function JoinGroupModal({ isOpen, onClose }) {
         <div className="p-6">
           {/* Header */}
           <div className="flex justify-between items-center mb-6">
-            <h2 className="text-2xl font-bold" style={{color: 'black'}}>Join Group</h2>
+            <h2 className="text-2xl font-bold" style={{color: 'var(--text)'}}>Join Group</h2>
             <button
               onClick={onClose}
               className="hover:opacity-70 text-2xl"
-              style={{color: 'black'}}
+              style={{color: 'var(--text)'}}
             >
               ×
             </button>
@@ -86,14 +86,14 @@ export default function JoinGroupModal({ isOpen, onClose }) {
           {/* Illustration */}
           <div className="text-center mb-6">
             <div className="text-6xl mb-4">📨</div>
-            <p style={{color: 'black'}}>
+            <p style={{color: 'var(--text)'}}>
               Enter the invite code shared by your group organizer to join their travel group.
             </p>
           </div>
 
           {/* Invite Code Input */}
           <div className="mb-6">
-            <label className="block text-sm font-medium mb-2" style={{color: 'black'}}>
+            <label className="block text-sm font-medium mb-2" style={{color: 'var(--text)'}}>
               Invite Code
             </label>
             <input
@@ -105,7 +105,7 @@ export default function JoinGroupModal({ isOpen, onClose }) {
               maxLength={6}
               style={{ letterSpacing: '0.3em', color: 'black', backgroundColor: 'white' }}
             />
-            <p className="text-xs mt-2 text-center" style={{color: 'black'}}>
+            <p className="text-xs mt-2 text-center" style={{color: 'var(--text)'}}>
               Code format: ABC123 (6 characters)
             </p>
           </div>
@@ -115,7 +115,7 @@ export default function JoinGroupModal({ isOpen, onClose }) {
             <button
               onClick={onClose}
               className="flex-1 py-3 px-4 border border-gray-300 rounded-lg hover:bg-gray-50 transition duration-200"
-              style={{color: 'black', backgroundColor: 'white'}}
+              style={{color: 'var(--text)', backgroundColor: 'var(--bg)'}}
             >
               Cancel
             </button>
@@ -134,7 +134,7 @@ export default function JoinGroupModal({ isOpen, onClose }) {
 
           {/* Help Text */}
           <div className="mt-4 p-4 bg-blue-50 rounded-lg">
-            <p className="text-sm" style={{color: 'black'}}>
+            <p className="text-sm" style={{color: 'var(--text)'}}>
               <strong>Don't have an invite code?</strong><br/>
               Ask the group creator to share their 6-character invite code with you, 
               or create your own group instead.


### PR DESCRIPTION
Adjust GoSplit component text colors to properly support dark theme.

Text in GoSplit components remained black when the dark theme was active, making it unreadable. This PR updates the components to use CSS variables (`var(--text)`) for text color, ensuring it adapts correctly to the selected theme.

---
<a href="https://cursor.com/background-agent?bcId=bc-d739f066-a0de-458a-a433-8444a507da73">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d739f066-a0de-458a-a433-8444a507da73">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>